### PR TITLE
chore(docs): strip CLAUDE.md boilerplate now covered by plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,41 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Auto-memory policy
-
-**Do NOT use MEMORY.md.** Claude Code's auto-memory feature stores behavioral
-rules outside of version control, making them invisible to code review,
-inconsistent across repos, and unreliable across sessions. All behavioral rules,
-conventions, and workflow instructions belong in managed, version-controlled
-documentation (CLAUDE.md, AGENTS.md, skills, or docs/).
-
-If you identify a pattern, convention, or rule worth preserving:
-
-1. **Stop.** Do not write to MEMORY.md.
-2. **Discuss with the user** what you want to capture and why.
-3. **Together, decide** the correct managed location (CLAUDE.md, a skill file,
-   standards docs, or a new issue to track the gap).
-
-This policy exists because MEMORY.md is per-directory and per-machine — it
-creates divergent agent behavior across the multi-repo environment this project
-operates in. Consistency requires all guidance to live in shared, reviewable
-documentation.
-
-## Shell command policy
-
-**Do NOT use heredocs** (`<<EOF` / `<<'EOF'`) for multi-line arguments to CLI
-tools such as `gh`, `git commit`, or `curl`. Heredocs routinely fail due to
-shell escaping issues with apostrophes, backticks, and special characters.
-Always write multi-line content to a temporary file and pass it via `--body-file`
-or `--file` instead.
-
-## Documentation Strategy
-
-This repository uses two complementary approaches for AI agent guidance:
-
-- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
-- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
-
 <!-- include: docs/standards-and-conventions.md -->
 <!-- include: docs/repository-standards.md -->
 
@@ -50,8 +15,6 @@ translation between {{LANGUAGE}} idioms and native MQSC parameter names.
 **Project name**: {{PROJECT_NAME}}
 
 **Status**: Pre-alpha (initial setup)
-
-**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
 
 ## Development Commands
 
@@ -172,54 +135,7 @@ Container details:
 
 {{ARCHITECTURE_SECTION}}
 
-## Branching and PR Workflow
-
-- **Protected branches**: `main`, `develop` — no direct commits (enforced by pre-commit hook)
-- **Branch naming**: `feature/*`, `bugfix/*`, `hotfix/*`, `chore/*`, or `release/*` only
-- **Feature/bugfix PRs** target `develop` with squash merge
-- **Release PRs** target `main` with regular merge
-- **Pre-flight**: Always check branch with `git status -sb` before modifying files. If on `develop`, create a `feature/*` branch first.
-
-## Commit and PR Scripts
-
-**NEVER use raw `git commit`** — always use `st-commit`.
-**NEVER use raw `gh pr create`** — always use `st-submit-pr`.
-
-### Committing
-
-```bash
-st-commit --type feat --scope {{SCOPE}} --message "add new feature" --agent claude
-st-commit --type fix --message "correct bug" --agent claude
-st-commit --type docs --message "update README" --body "Expanded usage section" --agent claude
-```
-
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
-- `--message` (required): commit description
-- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
-- `--scope` (optional): conventional commit scope
-- `--body` (optional): detailed commit body
-
-### Submitting PRs
-
-```bash
-st-submit-pr --issue 42 --summary "Add new feature"
-st-submit-pr --issue 42 --linkage Ref --summary "Update docs"
-st-submit-pr --issue 42 --summary "Fix bug" --notes "Tested on macOS and Linux"
-```
-
-- `--issue` (required): GitHub issue number (just the number)
-- `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
-- `--title` (optional): PR title (default: most recent commit subject)
-- `--notes` (optional): additional notes
-- `--dry-run` (optional): print generated PR without executing
-
 ## Key References
-
-**Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions>
-
-- Local path (preferred): `../standards-and-conventions`
-- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
 
 **Reference implementation**: `../mq-rest-admin-python` (Python version)
 
@@ -227,5 +143,3 @@ st-submit-pr --issue 42 --summary "Fix bug" --notes "Tested on macOS and Linux"
 
 - IBM MQ 9.4 administrative REST API
 - MQSC command reference
-
-**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)


### PR DESCRIPTION
# Pull Request

## Summary

- Strip CLAUDE.md boilerplate sections now enforced by standard-tooling plugin

## Issue Linkage

- Fixes #10

## Testing

- markdownlint
- `{{VALIDATION_COMMAND}}`

## Notes

- -