### PR TITLE
Container-first validation: remove fallback docker run blocks

### DIFF
--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -8,19 +8,9 @@ export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-{{DOCKER_AUDIT_COMMAND}}}"
 # Example (Go):     govulncheck ./... && go-licenses check ./... --allowed_licenses=...
 # Example (Java):   ./mvnw dependency:tree -B -q && ./mvnw license:add-third-party ...
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -8,19 +8,9 @@ export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-{{DOCKER_LINT_COMMAND}}}"
 # Example (Go):     go vet ./... && golangci-lint run ./... && gocyclo -over 15 ./mqrestadmin/
 # Example (Java):   ./mvnw spotless:check checkstyle:check -B
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -8,19 +8,9 @@ export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-{{DOCKER_TEST_COMMAND}}}"
 # Example (Go):     go vet ./... && go test -race -count=1 -coverprofile=coverage.out ./...
 # Example (Java):   ./mvnw verify -B
 
-if command -v docker-test >/dev/null 2>&1; then
-  exec docker-test
+if ! command -v docker-test >/dev/null 2>&1; then
+  echo "ERROR: docker-test not found on PATH." >&2
+  echo "Set up standard-tooling: export PATH=../standard-tooling/scripts/bin:\$PATH" >&2
+  exit 1
 fi
-
-# Fallback: run docker directly if docker-test is not on PATH.
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-
-echo "Image:   ${DOCKER_DEV_IMAGE}"
-echo "Command: ${DOCKER_TEST_CMD}"
-echo "---"
-
-exec docker run --rm \
-  -v "${repo_root}:/workspace" \
-  -w /workspace \
-  "${DOCKER_DEV_IMAGE}" \
-  bash -c "${DOCKER_TEST_CMD}"
+exec docker-test


### PR DESCRIPTION
## Summary
- Remove fallback `docker run` blocks from template dev scripts
- Require `docker-test` on PATH with clear error message

## Test plan
- [ ] Verify template scripts have correct structure
- [ ] Instantiate template and verify dev scripts work

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)