### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     # Skip on the template repo itself — placeholders like {{CODEQL_LANGUAGE}}
     # are only meaningful after instantiation into a real repo.
     if: github.repository != 'wphillipmoore/mq-rest-admin-template'
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     with:
       language: "{{CODEQL_LANGUAGE}}"
       # If Semgrep uses a different language name (e.g., "golang" for Go),
@@ -68,7 +68,7 @@ jobs:
       # {{LANGUAGE_SETUP}}
       # Example (Python):
       #   - name: Set up Python
-      #     uses: wphillipmoore/standard-actions/actions/python/setup@develop
+      #     uses: wphillipmoore/standard-actions/actions/python/setup@v1.3
       #     with:
       #       python-version: "3.14"
       # Example (Go):
@@ -129,7 +129,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
         with:
           head-version-command: "{{HEAD_VERSION_CMD}}"
           main-version-command: "{{MAIN_VERSION_CMD}}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       # Language-specific setup for documentation tools.
       # Example (Python):
       #   - name: Set up Python
-      #     uses: wphillipmoore/standard-actions/actions/python/setup@develop
+      #     uses: wphillipmoore/standard-actions/actions/python/setup@v1.3
       #     with:
       #       python-version: "3.14"
       #       cache-prefix: "uv-docs"
@@ -36,7 +36,7 @@ jobs:
       #     run: uv sync --frozen --group docs
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: "{{DOCS_VERSION_COMMAND}}"
           # Example (Python):

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Generate SBOM
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.3
         with:
           scan-type: sbom
           output-file: "dist/{{PACKAGE_NAME}}-${{ steps.version.outputs.version }}.cdx.json"
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.3
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: "{{PACKAGE_NAME}}"
@@ -99,7 +99,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.3
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: "{{VERSION_FILE}}"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #19

## Testing

- markdownlint
- `{{VALIDATION_COMMAND}}`

## Notes

- Pins all standard-actions refs to @v1.3 rolling minor tag. As this is the template repo, the change ensures new repos cloned from it inherit the @v1.3 pin from day one. Tracking: standard-actions#145.