### PR TITLE
chore: bump standard-actions pins from v1.3 to v1.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       # Language-specific setup for documentation tools.
       # Example (Python):
       #   - name: Set up Python
-      #     uses: wphillipmoore/standard-actions/actions/python/setup@v1.3
+      #     uses: wphillipmoore/standard-actions/actions/python/setup@v1.4
       #     with:
       #       python-version: "3.14"
       #       cache-prefix: "uv-docs"
@@ -36,7 +36,7 @@ jobs:
       #     run: uv sync --frozen --group docs
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
         with:
           version-command: "{{DOCS_VERSION_COMMAND}}"
           # Example (Python):

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Generate SBOM
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.3
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
         with:
           scan-type: sbom
           output-file: "dist/{{PACKAGE_NAME}}-${{ steps.version.outputs.version }}.cdx.json"
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.3
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: "{{PACKAGE_NAME}}"
@@ -99,7 +99,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.3
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: "{{VERSION_FILE}}"


### PR DESCRIPTION
# Pull Request

## Summary

- Bump all standard-actions pins from v1.3 to v1.4 (docs-deploy, trivy, tag-and-release, version-bump-pr, python/setup in comment)

## Issue Linkage

- Ref #26

## Testing

- markdownlint
- `{{VALIDATION_COMMAND}}`

## Notes

- -